### PR TITLE
TST: Print OGG support if "build-flac" is not enabled

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
           override: true
       - name: Run tests against external libraries
         run: |
-          cargo test --workspace --no-default-features
+          cargo test --workspace --no-default-features -- --nocapture
 
   check-code:
     runs-on: ubuntu-latest

--- a/tests/ogg_support.rs
+++ b/tests/ogg_support.rs
@@ -1,10 +1,9 @@
 #[test]
-#[cfg(feature = "build-flac")]
 fn ogg_support() {
-    unsafe {
-        assert_eq!(
-            libflac_sys::FLAC_API_SUPPORTS_OGG_FLAC,
-            cfg!(feature = "build-ogg").into()
-        );
+    let supports_ogg = unsafe { libflac_sys::FLAC_API_SUPPORTS_OGG_FLAC == 1 };
+    if cfg!(feature = "build-flac") {
+        assert_eq!(supports_ogg, cfg!(feature = "build-ogg"));
+    } else {
+        println!("external libFLAC supports OGG: {}", supports_ogg);
     }
 }


### PR DESCRIPTION
We cannot check for OGG support if `build-flac` is disabled (because we don't know about it), but at least we can print it out.