### PR TITLE
Use patched FLAC 1.3.4+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,7 @@ jobs:
             make
             mingw-w64-x86_64-cmake
             mingw-w64-x86_64-rust
+            mingw-w64-clang-x86_64-libssp
       - name: Clone Git repository
         uses: actions/checkout@v2
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "flac"]
 	path = flac
-	url = https://github.com/xiph/flac.git
+	url = https://github.com/mgeier/flac.git
 [submodule "ogg"]
 	path = ogg
 	url = https://github.com/xiph/ogg.git


### PR DESCRIPTION
This is a possible alternative to #20.

It uses a custom FLAC fork (https://github.com/mgeier/flac/commits/1.3.4+) to pull in the MinGW fixes.

Sadly, this doesn't compile yet ...

Any ideas how to fix this?