### PR TITLE
CI: re-add windows-gnu and fix build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,8 @@ jobs:
       matrix:
         include:
         - os: macos-latest
-        #- os: windows-latest
-        #  toolchain-suffix: -gnu
+        - os: windows-latest
+          toolchain-suffix: -gnu
         - os: windows-latest
           toolchain-suffix: -msvc
         - os: ubuntu-latest

--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,7 @@ fn main() {
         .define("BUILD_EXAMPLES", "OFF")
         .define("BUILD_TESTING", "OFF")
         .define("BUILD_DOCS", "OFF")
+        .define("WITH_STACK_PROTECTOR", "OFF")
         .define("INSTALL_MANPAGES", "OFF")
         .define("INSTALL_PKGCONFIG_MODULES", "OFF")
         .define("INSTALL_CMAKE_CONFIG_MODULE", "OFF");


### PR DESCRIPTION
This means disabling the stack protector, but it seems many Linux distros do this anyway.