### PR TITLE
TEST: Don't use get_unchecked() to access zero-element array

### DIFF
--- a/tests/strings.rs
+++ b/tests/strings.rs
@@ -5,7 +5,11 @@ use libflac_sys as ffi;
 #[test]
 fn strings() {
     let idx = ffi::FLAC__STREAM_METADATA_PICTURE_TYPE_FISH as usize;
-    let ptr = unsafe { *ffi::FLAC__StreamMetadata_Picture_TypeString.get_unchecked(idx) };
+    let ptr = unsafe {
+        *ffi::FLAC__StreamMetadata_Picture_TypeString
+            .as_ptr()
+            .add(idx)
+    };
     let c_string = unsafe { CStr::from_ptr(ptr) };
     assert_eq!(c_string.to_str().unwrap(), "A bright coloured fish");
 }


### PR DESCRIPTION
This is a work-around to avoid a panic in the test, but maybe there is a better solution?

Hopefully I'll get some answers at https://github.com/rust-lang/rust-bindgen/issues/2883.