### PR TITLE
CI: remove windows-gnu work-around

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,14 +12,10 @@ jobs:
         - os: macos-latest
         - os: windows-latest
           toolchain-suffix: -gnu
-          env:
-            # https://github.com/rust-lang/rust/issues/68973
-            RUSTFLAGS: "-Clink-arg=-lssp_nonshared -Clink-arg=-lssp"
         - os: windows-latest
           toolchain-suffix: -msvc
         - os: ubuntu-latest
     runs-on: ${{ matrix.os }}
-    env: ${{ matrix.env || fromJSON('{}') }}
     steps:
       - name: Clone Git repository
         uses: actions/checkout@v5


### PR DESCRIPTION
This caused an error (https://github.com/mgeier/libflac-sys/actions/runs/18247414310/job/51957233383):

```
  = note: C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: cannot find -lssp_nonshared: No such file or directory␍
          C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: cannot find -lssp: No such file or directory␍
```

This work-around doesn't seem to be necessary anymore.